### PR TITLE
Bugfix/DEV-228 Updated xmlCrypto.xpath.SelectNodes reference to xmlCrypto.xpath

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -164,7 +164,7 @@ SAML.prototype.certToPEM = function (cert) {
 SAML.prototype.validateSignature = function (xml, cert) {
   var self = this;
   var doc = new xmldom.DOMParser().parseFromString(xml);
-  var signature = xmlCrypto.xpath.SelectNodes(doc, "//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];
+  var signature = xmlCrypto.xpath(doc, "//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];
   var sig = new xmlCrypto.SignedXml();
   sig.keyInfoProvider = {
     getKeyInfo: function (key) {


### PR DESCRIPTION
'xmlCrypto.xpath' is the function SelectNodes(doc, path)
Refer: https://github.com/MSOpenTech/passport-azure-ad/issues/4
