### PR TITLE
bugfix/KB-5923: Fix to handle different saml versions

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -189,13 +189,13 @@ SAML.prototype.validateSignature = function (xml, cert) {
 };
 
 SAML.prototype.getElement = function (parentElement, elementName) {
-  var parentElementString = JSON.stringify(parentElement);
-  var pattern = new RegExp("(.*)" + elementName, "m");
-  var patternMatch = parentElementString.match(pattern)[1];
-  var elementPrefix = patternMatch.substr(patternMatch.lastIndexOf('"'));
-  var elemName = elementPrefix.substr(1) + elementName;
-
-  return parentElement[elemName];
+  var prefix = ['saml:', 'samlp:', 'saml2:', 'saml2p:'];
+  for(var i = 0; i < prefix.length; i++) {
+    if(parentElement[prefix[i]+elementName]) {
+      return parentElement[prefix[i]+elementName];
+    }
+  }
+  return parentElement[elementName];
 };
 
 


### PR DESCRIPTION
Due to different saml versions which we may receive from a saml response provider (IDPs), we need to support keys which have prefix saml or saml2.
This was being done using a regexp. But the regexp match was flawed and failed for some scenarios.
This has been fixed using a simpler approach.